### PR TITLE
fix: before interval should not include FIRST date of interval

### DIFF
--- a/src/calcStartingValueHistory.js
+++ b/src/calcStartingValueHistory.js
@@ -1,6 +1,6 @@
 const partition = require('lodash/partition');
 const sumBy = require('lodash/sumBy');
-const isAfter = require('date-fns/isAfter');
+const isBefore = require('date-fns/isBefore');
 
 const calcInventoryPurchasesFIFO = require('./calcInventoryPurchasesFIFO');
 const calcCurrentShares = require('./calcCurrentShares');
@@ -13,9 +13,8 @@ module.exports = function (activities, interval, priceAtStart) {
   activities = applySplitMultiplier(activities);
 
   const startDate = new Date(interval.start);
-  const [activitiesBeforeInterval, activitiesInInterval] = partition(
-    activities,
-    (a) => !isAfter(new Date(a.date), startDate),
+  const [activitiesBeforeInterval, activitiesInInterval] = partition(activities, (a) =>
+    isBefore(new Date(a.date), startDate),
   );
 
   const sharesAtStart = calcCurrentShares(activitiesBeforeInterval);

--- a/src/calcStartingValueHistory.js
+++ b/src/calcStartingValueHistory.js
@@ -1,6 +1,7 @@
 const partition = require('lodash/partition');
 const sumBy = require('lodash/sumBy');
 const isBefore = require('date-fns/isBefore');
+const isAfter = require('date-fns/isAfter');
 
 const calcInventoryPurchasesFIFO = require('./calcInventoryPurchasesFIFO');
 const calcCurrentShares = require('./calcCurrentShares');


### PR DESCRIPTION
`!isAfter` will be true if two dates are on the same day.

Imagine we request portfolio data, beginning at the start of the year: `2021-01-01`. If an activity took place on the same date, `!isAfter` would've been truthy. That activity was sorted into `activitiesBeforeInterval`.  Obviously, we don't want that!

In the case of `isBefore`: `2021-01-01` is NOT before `2021-01-01`, so the activity gets sorted into `activitiesInInterval`. 

