### PR TITLE
fix: normalizeQuotes should respect quotes that happen before the given interval (Based on #17)

### DIFF
--- a/src/calcStartingValueHistory.js
+++ b/src/calcStartingValueHistory.js
@@ -1,6 +1,6 @@
 const partition = require('lodash/partition');
 const sumBy = require('lodash/sumBy');
-const isAfter = require('date-fns/isAfter');
+const isBefore = require('date-fns/isBefore');
 
 const calcInventoryPurchasesFIFO = require('./calcInventoryPurchasesFIFO');
 const calcCurrentShares = require('./calcCurrentShares');
@@ -13,9 +13,8 @@ module.exports = function (activities, interval, priceAtStart) {
   activities = applySplitMultiplier(activities);
 
   const startDate = new Date(interval.start);
-  const [activitiesBeforeInterval, activitiesInInterval] = partition(
-    activities,
-    (a) => !isAfter(new Date(a.date), startDate),
+  const [activitiesBeforeInterval, activitiesInInterval] = partition(activities, (a) =>
+    isBefore(new Date(a.date), startDate),
   );
 
   const sharesAtStart = calcCurrentShares(activitiesBeforeInterval);

--- a/src/calcStartingValueHistory.js
+++ b/src/calcStartingValueHistory.js
@@ -1,6 +1,7 @@
 const partition = require('lodash/partition');
 const sumBy = require('lodash/sumBy');
 const isBefore = require('date-fns/isBefore');
+const isAfter = require('date-fns/isAfter');
 
 const calcInventoryPurchasesFIFO = require('./calcInventoryPurchasesFIFO');
 const calcCurrentShares = require('./calcCurrentShares');


### PR DESCRIPTION
If we request a quote for a Sunday, our exchanges can't provide us with that. Up to this point, `normalizeQuotes` would look at the next days to find a quote: Given our example, it would check Monday, find a price, and fill up the missing Sunday-Space with the Monday's quote.

This is inconsistent. We are using future data to provide past data. It should only be used as a last resort.

Passing older quotes into the function didn't have any effect; `normalizeQuotes` simply ignored them. This PR makes it so that if we request data that starts on a Sunday, and we pass in a quote from the previous Friday, `normalizeQuotes`gets _THE FRIDAYS_ price and fills up the gaps. It is now able to use past data to fill in missing spots.

