### PR TITLE
fix: calculation order, calculate against beforeIntervalActivity first

### DIFF
--- a/src/calcStartingValueHistory.js
+++ b/src/calcStartingValueHistory.js
@@ -39,8 +39,8 @@ module.exports = function (activities, interval, priceAtStart) {
 
     // interval data, including the purchases before the interval as one starting purchase activity
     const { purchases: purchasesForInterval, realizedGains } = calcInventoryPurchasesFIFO([
-      ...activitiesUntilNow,
       beforeIntervalActivity,
+      ...activitiesUntilNow,
     ]);
 
     // starting value is the value of the holding at the beginning of the interval

--- a/src/calcValueHistory.js
+++ b/src/calcValueHistory.js
@@ -44,7 +44,7 @@ module.exports = function (activities, quotes, interval, i) {
     };
 
     const todaysActivities = activitiesInInterval.filter((a) => day === a.date);
-    const activitiesUntilNow = [...todaysActivities, beforeIntervalActivity];
+    const activitiesUntilNow = [beforeIntervalActivity, ...todaysActivities];
     const { purchases: purchasesUntilNow } = calcInventoryPurchasesFIFO(activitiesUntilNow);
 
     const { purchaseValue } = calcPurchasePrice(purchasesUntilNow);


### PR DESCRIPTION
We should calculate against "beforeIntervalActivity" FIRST, before heading over to the activities in the interval. Very odd.