### PR TITLE
feat(invested): add invested history

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
-const calcCurrentShares = require('./src/calcCurrentShares')
-const calcValueHistory = require('./src/calcValueHistory')
-const calcStartingValueHistory = require('./src/calcStartingValueHistory')
-const calcInventoryPurchasesFIFO = require('./src/calcInventoryPurchasesFIFO')
-const calcPurchasePrice = require('./src/calcPurchasePrice')
-const utils = require('./utils')
+const calcCurrentShares = require('./src/calcCurrentShares');
+const calcValueHistory = require('./src/calcValueHistory');
+const calcStartingValueHistory = require('./src/calcStartingValueHistory');
+const calcInventoryPurchasesFIFO = require('./src/calcInventoryPurchasesFIFO');
+const calcPurchasePrice = require('./src/calcPurchasePrice');
+const calcInvestedCapitalHistory = require('./src/calcInvestedCapitalHistory');
+const utils = require('./utils');
 
 module.exports = {
   calcInventoryPurchasesFIFO,
   calcPurchasePrice,
+  calcInvestedCapitalHistory,
   calcCurrentShares,
   calcValueHistory,
   calcStartingValueHistory,
-  utils
-}
+  utils,
+};

--- a/src/calcInventoryPurchasesFIFO.js
+++ b/src/calcInventoryPurchasesFIFO.js
@@ -21,8 +21,8 @@ module.exports = function calcInventoryPurchasesFIFO(activities, startDate) {
   const purchases = cloneDeep(reverse(activities.filter((a) => ['Buy', 'TransferIn'].includes(a.type))));
 
   let realized = 0;
-  let sellAmount = 0;
-  let transferOutAmount = 0;
+  let capitalWidthdrawnViaSales = 0;
+  let capitalWithdrawnViaTransferOut = 0;
 
   sales.forEach(({ shares, price, date, type }) => {
     // loop through each sale, then subtract the sold shares from the first buy(s)
@@ -46,10 +46,9 @@ module.exports = function calcInventoryPurchasesFIFO(activities, startDate) {
           // realized gains through sales
           realized += (price - buyPrice) * Math.min(buyShares, sellShares);
 
-          // ! sellAmount is the capital widthdran through sales
-          sellAmount += buyPrice * Math.min(buyShares, sellShares);
+          capitalWidthdrawnViaSales += buyPrice * Math.min(buyShares, sellShares);
         } else if (type === 'TransferOut') {
-          transferOutAmount += buyPrice * Math.min(buyShares, sellShares);
+          capitalWithdrawnViaTransferOut += buyPrice * Math.min(buyShares, sellShares);
         }
       }
 
@@ -64,7 +63,15 @@ module.exports = function calcInventoryPurchasesFIFO(activities, startDate) {
     subtract(0, shares);
   });
 
-  const capitalWithdrawn = sellAmount + transferOutAmount;
+  const capitalWithdrawn = capitalWidthdrawnViaSales + capitalWithdrawnViaTransferOut;
 
-  return { realizedGains: realized, purchases, capitalWithdrawn, transferOutAmount, sellAmount };
+  return {
+    realizedGains: realized,
+    purchases,
+    capitalWithdrawn,
+    transferOutAmount: capitalWithdrawnViaTransferOut, // deprecated
+    capitalWithdrawnViaTransferOut,
+    sellAmount: capitalWidthdrawnViaSales, // deprecated
+    capitalWidthdrawnViaSales,
+  };
 };

--- a/src/calcInventoryPurchasesFIFO.js
+++ b/src/calcInventoryPurchasesFIFO.js
@@ -43,7 +43,10 @@ module.exports = function calcInventoryPurchasesFIFO(activities, startDate) {
       if (!isBefore(new Date(date), startDate)) {
         // TransferOut does not create "realized Gains"
         if (type === 'Sell') {
+          // realized gains through sales
           realized += (price - buyPrice) * Math.min(buyShares, sellShares);
+
+          // ! sellAmount is the capital widthdran through sales
           sellAmount += buyPrice * Math.min(buyShares, sellShares);
         } else if (type === 'TransferOut') {
           transferOutAmount += buyPrice * Math.min(buyShares, sellShares);

--- a/src/calcInvestedCapitalHistory.js
+++ b/src/calcInvestedCapitalHistory.js
@@ -13,15 +13,15 @@ module.exports = function (activities, interval) {
   }
 
   // adjust shares bought/sold by splits that happened in the past
-  const tempActivities = applySplitMultiplier(activities);
+  const splitAdjustedActivities = applySplitMultiplier(activities);
 
   // add "buyAmount" do sales data
-  const adjustedActivities = calcSalesDataFIFO(tempActivities);
+  const fifoActivities = calcSalesDataFIFO(splitAdjustedActivities);
 
   // create an array of all days from today to the first activity
   // we ignore the passed interval here because the calculation needs to happen across the entire activities array
   // with the passed interval, we will just cut off the resulting array
-  const earliestActivity = minBy(adjustedActivities, (a) => new Date(a.date));
+  const earliestActivity = minBy(fifoActivities, (a) => new Date(a.date));
   const dateArr = getDateArr({
     start: earliestActivity.date,
     end: format(new Date(), 'yyyy-MM-dd'),
@@ -35,7 +35,7 @@ module.exports = function (activities, interval) {
     const thatDay = format(new Date(d), 'yyyy-MM-dd');
 
     // find activities from thatDay and add the buy amounts and subtract a sales original buyAmount to get the capitalFlow
-    const activitiesForInvestedValue = adjustedActivities
+    const activitiesForInvestedValue = fifoActivities
       .filter((a) => a.date === thatDay)
       .filter((a) => ['Sell', 'Buy'].includes(a.type))
       .map((a) => {

--- a/src/calcInvestedCapitalHistory.js
+++ b/src/calcInvestedCapitalHistory.js
@@ -13,15 +13,15 @@ module.exports = function (activities, interval) {
   }
 
   // adjust shares bought/sold by splits that happened in the past
-  activities = applySplitMultiplier(activities);
+  const tempActivities = applySplitMultiplier(activities);
 
   // add "buyAmount" do sales data
-  activities = calcSalesDataFIFO(activities);
+  const adjustedActivities = calcSalesDataFIFO(tempActivities);
 
   // create an array of all days from today to the first activity
   // we ignore the passed interval here because the calculation needs to happen across the entire activities array
   // with the passed interval, we will just cut off the resulting array
-  const earliestActivity = minBy(activities, (a) => new Date(a.date));
+  const earliestActivity = minBy(adjustedActivities, (a) => new Date(a.date));
   const dateArr = getDateArr({
     start: earliestActivity.date,
     end: format(new Date(), 'yyyy-MM-dd'),
@@ -35,7 +35,7 @@ module.exports = function (activities, interval) {
     const thatDay = format(new Date(d), 'yyyy-MM-dd');
 
     // find activities from thatDay and add the buy amounts and subtract a sales original buyAmount to get the capitalFlow
-    const activitiesForInvestedValue = activities
+    const activitiesForInvestedValue = adjustedActivities
       .filter((a) => a.date === thatDay)
       .filter((a) => ['Sell', 'Buy'].includes(a.type))
       .map((a) => {

--- a/src/calcInvestedCapitalHistory.js
+++ b/src/calcInvestedCapitalHistory.js
@@ -1,10 +1,8 @@
 const sumBy = require('lodash/sumBy');
-const partition = require('lodash/partition');
-const isBefore = require('date-fns/isBefore');
 
 const { applySplitMultiplier, getDateArr, normalizeQuotes } = require('../utils');
 const { format } = require('date-fns');
-const { cloneDeep, orderBy, subtract } = require('lodash');
+const { cloneDeep, orderBy } = require('lodash');
 const Big = require('big.js');
 
 function calcSalesDataFIFO(activities) {

--- a/src/calcInvestedCapitalHistory.js
+++ b/src/calcInvestedCapitalHistory.js
@@ -1,0 +1,96 @@
+const sumBy = require('lodash/sumBy');
+const partition = require('lodash/partition');
+const isBefore = require('date-fns/isBefore');
+
+const { applySplitMultiplier, getDateArr, normalizeQuotes } = require('../utils');
+const { format } = require('date-fns');
+const { cloneDeep, orderBy, subtract } = require('lodash');
+const Big = require('big.js');
+
+function calcSalesDataFIFO(activities) {
+  activities = orderBy(cloneDeep(activities), 'date', 'asc');
+
+  // we will make changes to sales that should be reflected in the activities collection
+  const sales = activities.filter((a) => ['Sell', 'TransferOut'].includes(a.type));
+
+  // we clone purchases again as the changes we will make below are temporary and should not be returned
+  const purchases = cloneDeep(activities.filter((a) => ['Buy', 'TransferIn'].includes(a.type)));
+
+  sales.forEach((sale) => {
+    const { shares } = sale;
+    sale.buyAmount = 0;
+
+    function calc(sellShares) {
+      const purchase = purchases[0];
+      if (!purchase) {
+        return;
+      }
+
+      const buyShares = purchase.shares;
+      const buyPrice = purchase.price;
+
+      const sharesSoldInThisPurchase = Math.min(buyShares, sellShares);
+      const remainingShares = +Big(buyShares).minus(Big(sellShares));
+
+      purchase.shares = remainingShares;
+      sale.buyAmount += buyPrice * sharesSoldInThisPurchase;
+
+      if (remainingShares <= 0) {
+        purchases.shift();
+      }
+
+      if (remainingShares < 0) {
+        calc(Math.abs(remainingShares));
+      }
+    }
+
+    calc(shares);
+  });
+
+  return activities;
+}
+
+module.exports = function (activities, interval) {
+  if (activities.length === 0) {
+    return {
+      capitalHistory: [],
+      dates: [],
+    };
+  }
+
+  // adjust shares bought/sold by splits that happened in the past
+  activities = applySplitMultiplier(activities);
+
+  // add "buyAmount" do sales data
+  activities = calcSalesDataFIFO(activities);
+
+  // create an array of all days from today to the first activity
+  const dateArr = getDateArr(interval);
+
+  const capitalHistory = [];
+  let investedStorage = 0;
+
+  dateArr.forEach((d) => {
+    const thatDay = format(new Date(d), 'yyyy-MM-dd');
+
+    // find activities from thatDay and add the buy amounts and subtract a sales original buyAmount to get the capitalFlow
+    const activitiesForInvestedValue = activities
+      .filter((a) => a.date === thatDay)
+      .filter((a) => ['Sell', 'Buy'].includes(a.type))
+      .map((a) => {
+        return {
+          ...a,
+          capitalFlow: a.type === 'Sell' ? a.buyAmount * -1 : a.amount,
+        };
+      });
+
+    // add the capitalFlow over time, resulting in the capitalHistory
+    investedStorage += sumBy(activitiesForInvestedValue, 'capitalFlow');
+    capitalHistory.push(investedStorage);
+  });
+
+  return {
+    capitalHistory,
+    dates: dateArr,
+  };
+};

--- a/src/calcInvestedCapitalHistory.js
+++ b/src/calcInvestedCapitalHistory.js
@@ -14,34 +14,52 @@ function calcSalesDataFIFO(activities) {
   // we clone purchases again as the changes we will make below are temporary and should not be returned
   const purchases = cloneDeep(activities.filter((a) => ['Buy', 'TransferIn'].includes(a.type)));
 
+  /**
+   * Alright, in here we will loop through sales
+   * and then start with the first purchase to see how much we paid originally
+   * for the shares we are selling here
+   */
   sales.forEach((sale) => {
     const { shares } = sale;
     sale.buyAmount = 0;
 
+    // alright let's do the FIFO magic in here
     function calc(sellShares) {
       const purchase = purchases[0];
       if (!purchase) {
         return;
       }
 
+      // get the shares and the price of the first purchase
       const buyShares = purchase.shares;
       const buyPrice = purchase.price;
 
+      // check how many shares were actually sold in this purchase
       const sharesSoldInThisPurchase = Math.min(buyShares, sellShares);
+
+      // these are the remaining shares, in case we sold more shares than we bought in this purchase
+      // this means there are more purchases where we need to calc the remaining shares against
       const remainingShares = +Big(buyShares).minus(Big(sellShares));
 
+      // store the remaining shares on the purchase - for the next sale that will happen
       purchase.shares = remainingShares;
+
+      // store the amount of this purchase to our sale
       sale.buyAmount += buyPrice * sharesSoldInThisPurchase;
 
+      // if no shares are left (all of this purchase was sold in the sale), remove the purchase
       if (remainingShares <= 0) {
         purchases.shift();
       }
 
+      // if the remaining shares are negative (ie we sold more than we bought in this purchase)
+      // restart this calculation with the remaining shares as "sellShares"
       if (remainingShares < 0) {
         calc(Math.abs(remainingShares));
       }
     }
 
+    // kick FIFO off
     calc(shares);
   });
 

--- a/src/calcValueHistory.js
+++ b/src/calcValueHistory.js
@@ -1,4 +1,3 @@
-const sumBy = require('lodash/sumBy');
 const partition = require('lodash/partition');
 const isBefore = require('date-fns/isBefore');
 

--- a/src/calcValueHistory.js
+++ b/src/calcValueHistory.js
@@ -31,14 +31,6 @@ module.exports = function (activities, quotes, interval, i) {
   // get normalized quotes (so every day of dateArr has a price)
   const quotesNormalized = normalizeQuotes(quotes, dateArr);
 
-  // calc invested capital at the start of the interval
-  const { purchases: purchasesBeforeInterval } = calcInventoryPurchasesFIFO(activitiesBeforeInterval);
-  const investedBeforeInterval = sumBy(purchasesBeforeInterval, 'amount');
-  let investedStorage = investedBeforeInterval;
-
-  // invested capital over time
-  const investedInHoldingOverTime = [];
-
   let sharesStorage = sharesAtStart;
   const valueOfHoldingOverTime = dateArr.map((day, i) => {
     const currentPrice = quotesNormalized[i].price;
@@ -59,28 +51,11 @@ module.exports = function (activities, quotes, interval, i) {
 
     sharesStorage = calcCurrentShares(activitiesUntilNow);
 
-    // TODO: use todaysActivities and calcInventoryPurchasesFIFO to get todays purchases and sum the amount to get the invested value
-    // TODO: but not sure if its correct yet ... I might need unit tests for this
-    // also store the invested amount (based solely on activities) over time
-    const activitiesForInvestedValue = todaysActivities
-      .filter((a) => ['Sell', 'Buy'].includes(a.type))
-      .map((a) => {
-        return {
-          ...a,
-          amount: a.type === 'Sell' ? a.amount * -1 : a.amount,
-        };
-      });
-
-    // increase invested capital storage for next iteration and push into history
-    investedStorage += sumBy(activitiesForInvestedValue, 'amount');
-    investedInHoldingOverTime.push(investedStorage);
-
     return purchaseValue;
   });
 
   return {
     history: valueOfHoldingOverTime,
-    investedHistory: investedInHoldingOverTime,
     dates: dateArr,
   };
 };

--- a/src/calcValueHistory.js
+++ b/src/calcValueHistory.js
@@ -1,6 +1,6 @@
+const sumBy = require('lodash/sumBy');
 const partition = require('lodash/partition');
 const isBefore = require('date-fns/isBefore');
-const Big = require('big.js');
 
 const { applySplitMultiplier, getDateArr, normalizeQuotes } = require('../utils');
 const calcInventoryPurchasesFIFO = require('./calcInventoryPurchasesFIFO');
@@ -31,6 +31,22 @@ module.exports = function (activities, quotes, interval, i) {
   // get normalized quotes (so every day of dateArr has a price)
   const quotesNormalized = normalizeQuotes(quotes, dateArr);
 
+  // calc invested capital before interval
+  const activitiesForInvestedValueBeforeInterval = activitiesBeforeInterval
+    .filter((a) => ['Sell', 'Buy'].includes(a.type))
+    .map((a) => {
+      return {
+        ...a,
+        amount: a.type === 'Sell' ? a.amount * -1 : a.amount,
+      };
+    });
+
+  // calc invested capital at the start of the interval
+  let investedStorage = sumBy(activitiesForInvestedValueBeforeInterval, 'amount');
+
+  // invested capital over time
+  const investedInHoldingOverTime = [];
+
   let sharesStorage = sharesAtStart;
   const valueOfHoldingOverTime = dateArr.map((day, i) => {
     const currentPrice = quotesNormalized[i].price;
@@ -51,11 +67,26 @@ module.exports = function (activities, quotes, interval, i) {
 
     sharesStorage = calcCurrentShares(activitiesUntilNow);
 
+    // also store the invested amount (based solely on activities) over time
+    const activitiesForInvestedValue = todaysActivities
+      .filter((a) => ['Sell', 'Buy'].includes(a.type))
+      .map((a) => {
+        return {
+          ...a,
+          amount: a.type === 'Sell' ? a.amount * -1 : a.amount,
+        };
+      });
+
+    // increase invested capital storage for next iteration and push into history
+    investedStorage += sumBy(activitiesForInvestedValue, 'amount');
+    investedInHoldingOverTime.push(investedStorage);
+
     return purchaseValue;
   });
 
   return {
     history: valueOfHoldingOverTime,
+    investedHistory: investedInHoldingOverTime,
     dates: dateArr,
   };
 };

--- a/src/calcValueHistory.js
+++ b/src/calcValueHistory.js
@@ -31,18 +31,10 @@ module.exports = function (activities, quotes, interval, i) {
   // get normalized quotes (so every day of dateArr has a price)
   const quotesNormalized = normalizeQuotes(quotes, dateArr);
 
-  // calc invested capital before interval
-  const activitiesForInvestedValueBeforeInterval = activitiesBeforeInterval
-    .filter((a) => ['Sell', 'Buy'].includes(a.type))
-    .map((a) => {
-      return {
-        ...a,
-        amount: a.type === 'Sell' ? a.amount * -1 : a.amount,
-      };
-    });
-
   // calc invested capital at the start of the interval
-  let investedStorage = sumBy(activitiesForInvestedValueBeforeInterval, 'amount');
+  const { purchases: purchasesBeforeInterval } = calcInventoryPurchasesFIFO(activitiesBeforeInterval);
+  const investedBeforeInterval = sumBy(purchasesBeforeInterval, 'amount');
+  let investedStorage = investedBeforeInterval;
 
   // invested capital over time
   const investedInHoldingOverTime = [];
@@ -67,6 +59,8 @@ module.exports = function (activities, quotes, interval, i) {
 
     sharesStorage = calcCurrentShares(activitiesUntilNow);
 
+    // TODO: use todaysActivities and calcInventoryPurchasesFIFO to get todays purchases and sum the amount to get the invested value
+    // TODO: but not sure if its correct yet ... I might need unit tests for this
     // also store the invested amount (based solely on activities) over time
     const activitiesForInvestedValue = todaysActivities
       .filter((a) => ['Sell', 'Buy'].includes(a.type))

--- a/utils.js
+++ b/utils.js
@@ -2,6 +2,7 @@ const cloneDeep = require('lodash/cloneDeep');
 const filter = require('lodash/filter');
 const partition = require('lodash/partition');
 const keyBy = require('lodash/keyBy');
+const orderBy = require('lodash/orderBy');
 const Big = require('big.js');
 const { format, eachDayOfInterval, parse, isAfter, isBefore } = require('date-fns');
 
@@ -94,7 +95,69 @@ function getPreviousValue(arr, i) {
   }
 }
 
+function calcSalesDataFIFO(activities) {
+  activities = orderBy(cloneDeep(activities), 'date', 'asc');
+
+  // we will make changes to sales that should be reflected in the activities collection
+  const sales = activities.filter((a) => ['Sell', 'TransferOut'].includes(a.type));
+
+  // we clone purchases again as the changes we will make below are temporary and should not be returned
+  const purchases = cloneDeep(activities.filter((a) => ['Buy', 'TransferIn'].includes(a.type)));
+
+  /**
+   * Alright, in here we will loop through sales
+   * and then start with the first purchase to see how much we paid originally
+   * for the shares we are selling here
+   */
+  sales.forEach((sale) => {
+    const { shares } = sale;
+    sale.buyAmount = 0;
+
+    // alright let's do the FIFO magic in here
+    function calc(sellShares) {
+      const purchase = purchases[0];
+      if (!purchase) {
+        return;
+      }
+
+      // get the shares and the price of the first purchase
+      const buyShares = purchase.shares;
+      const buyPrice = purchase.price;
+
+      // check how many shares were actually sold in this purchase
+      const sharesSoldInThisPurchase = Math.min(buyShares, sellShares);
+
+      // these are the remaining shares, in case we sold more shares than we bought in this purchase
+      // this means there are more purchases where we need to calc the remaining shares against
+      const remainingShares = +Big(buyShares).minus(Big(sellShares));
+
+      // store the remaining shares on the purchase - for the next sale that will happen
+      purchase.shares = remainingShares;
+
+      // store the amount of this purchase to our sale
+      sale.buyAmount += buyPrice * sharesSoldInThisPurchase;
+
+      // if no shares are left (all of this purchase was sold in the sale), remove the purchase
+      if (remainingShares <= 0) {
+        purchases.shift();
+      }
+
+      // if the remaining shares are negative (ie we sold more than we bought in this purchase)
+      // restart this calculation with the remaining shares as "sellShares"
+      if (remainingShares < 0) {
+        calc(Math.abs(remainingShares));
+      }
+    }
+
+    // kick FIFO off
+    calc(shares);
+  });
+
+  return activities;
+}
+
 module.exports = {
+  calcSalesDataFIFO,
   applySplitMultiplier,
   getDateArr,
   normalizeQuotes,

--- a/utils.js
+++ b/utils.js
@@ -97,13 +97,13 @@ function getPreviousValue(arr, i) {
 
 function calcSalesDataFIFO(activities) {
   // order asc - it's necessary for a FIFO loop. earliest/oldest activity is first in the array. Latest/newest is last
-  activities = orderBy(cloneDeep(activities), 'date', 'asc');
+  orderedActivities = orderBy(cloneDeep(activities), 'date', 'asc');
 
   // we will make changes to sales that should be reflected in the activities collection
-  const sales = activities.filter((a) => ['Sell', 'TransferOut'].includes(a.type));
+  const sales = orderedActivities.filter((a) => ['Sell', 'TransferOut'].includes(a.type));
 
   // we clone purchases again as the changes we will make below are temporary and should not be returned
-  const purchases = cloneDeep(activities.filter((a) => ['Buy', 'TransferIn'].includes(a.type)));
+  const purchases = cloneDeep(orderedActivities.filter((a) => ['Buy', 'TransferIn'].includes(a.type)));
 
   /**
    * Alright, in here we will loop through sales
@@ -154,7 +154,7 @@ function calcSalesDataFIFO(activities) {
     calc(shares);
   });
 
-  return activities;
+  return orderedActivities;
 }
 
 module.exports = {

--- a/utils.js
+++ b/utils.js
@@ -96,6 +96,7 @@ function getPreviousValue(arr, i) {
 }
 
 function calcSalesDataFIFO(activities) {
+  // order asc - it's necessary for a FIFO loop. earliest/oldest activity is first in the array. Latest/newest is last
   activities = orderBy(cloneDeep(activities), 'date', 'asc');
 
   // we will make changes to sales that should be reflected in the activities collection


### PR DESCRIPTION
Add the history of invested capital per day.
Also adds a new utility function to enrich sell-activities with the original purchaseAmount. Very useful for different purposes
This will enable a value chart that includes invested amounts like this:

![image](https://user-images.githubusercontent.com/2399810/123231936-f72edc80-d4d8-11eb-8170-22608caced43.png)
