### PR TITLE
fix(fifo): don't rely on incoming activities order

### DIFF
--- a/benchmark/calcValueHistory/index.js
+++ b/benchmark/calcValueHistory/index.js
@@ -1,55 +1,46 @@
-const groupBy = require('lodash/groupBy')
-const orderBy = require('lodash/orderBy')
-const { format } = require('date-fns')
-const activities = require('./fixtures/activities.json')
-const quotes = require('./fixtures/quotes.json')
+const groupBy = require('lodash/groupBy');
+const orderBy = require('lodash/orderBy');
+const { format } = require('date-fns');
+const activities = require('./fixtures/activities.json');
+const quotes = require('./fixtures/quotes.json');
 
-const calcValueHistory = require('../../src/calcValueHistory')
+const calcValueHistory = require('../../src/calcValueHistory');
 
-const activitiesFilered = activities.filter(a =>
-  [
-    'Buy',
-    'Sell',
-    'split',
-    'reversesplit',
-    'TransferIn',
-    'TransferOut'
-  ].includes(a.type)
-)
+const activitiesFilered = activities.filter((a) =>
+  ['Buy', 'Sell', 'split', 'reversesplit', 'TransferIn', 'TransferOut'].includes(a.type),
+);
 
-const activitiesByHolding = groupBy(activitiesFilered, 'holding')
+const activitiesByHolding = groupBy(activitiesFilered, 'holding');
 
-function getEarliestActivity (values) {
+function getEarliestActivity(values) {
   if (!values.length) {
-    return format(new Date(), 'yyyy-MM-dd')
+    return format(new Date(), 'yyyy-MM-dd');
   }
 
-  return orderBy(values, ['date'], ['asc'])[0].date
+  return orderBy(values, (a) => new Date(a), ['asc'])[0].date;
 }
 
-const start = new Date()
+const start = new Date();
 
-Object.entries(activitiesByHolding).forEach(
-  ([holdingId, activitiesOfHolding]) => {
-    activitiesOfHolding = orderBy(activitiesOfHolding, 'date', 'desc').reverse()
-    const quotesOfHolding = quotes[holdingId]
-    const earliestActivity = getEarliestActivity(activitiesOfHolding)
-    const now = format(new Date(), 'yyyy-MM-dd')
+Object.entries(activitiesByHolding).forEach(([holdingId, activitiesOfHolding]) => {
+  activitiesOfHolding = orderBy(activitiesOfHolding, (a) => new Date(a), 'desc').reverse();
+  const quotesOfHolding = quotes[holdingId];
+  const earliestActivity = getEarliestActivity(activitiesOfHolding);
+  const now = format(new Date(), 'yyyy-MM-dd');
 
-    const interval = {
-      start: earliestActivity,
-      end: now
-    }
+  const interval = {
+    start: earliestActivity,
+    end: now,
+  };
 
-    calcValueHistory(activitiesOfHolding, quotesOfHolding, interval)
-  }
-)
+  calcValueHistory(activitiesOfHolding, quotesOfHolding, interval);
+});
 
-const end = new Date()
-const total = end - start
-const holdingsCount = Object.keys(activitiesByHolding).length
-const average = parseInt(total / holdingsCount, 10)
+const end = new Date();
+const total = end - start;
+const holdingsCount = Object.keys(activitiesByHolding).length;
+const average = parseInt(total / holdingsCount, 10);
 
 console.info(`Total:\t\t${total}ms
 Average: \t${average}ms
-Holdings:\t${holdingsCount}`)
+Holdings:\t${holdingsCount}`);

--- a/src/calcInventoryPurchasesFIFO.js
+++ b/src/calcInventoryPurchasesFIFO.js
@@ -26,8 +26,6 @@ module.exports = function calcInventoryPurchasesFIFO(activities, startDate) {
   let capitalWidthdrawnViaSales = 0;
   let capitalWithdrawnViaTransferOut = 0;
 
-  console.log(purchases, sales);
-
   sales.forEach(({ shares, price, date, type }) => {
     // loop through each sale, then subtract the sold shares from the first buy(s)
     // That's the FIFO principle (First in first out)
@@ -51,7 +49,6 @@ module.exports = function calcInventoryPurchasesFIFO(activities, startDate) {
           realized += (price - buyPrice) * Math.min(buyShares, sellShares);
 
           capitalWidthdrawnViaSales += buyPrice * Math.min(buyShares, sellShares);
-          console.log(buyPrice, buyShares, capitalWidthdrawnViaSales);
         } else if (type === 'TransferOut') {
           capitalWithdrawnViaTransferOut += buyPrice * Math.min(buyShares, sellShares);
         }

--- a/src/calcInventoryPurchasesFIFO.js
+++ b/src/calcInventoryPurchasesFIFO.js
@@ -17,7 +17,7 @@ module.exports = function calcInventoryPurchasesFIFO(activities, startDate) {
   // as it's properly looping through FIFO style already
 
   // order asc - it's necessary for a FIFO loop. earliest/oldest activity is first in the array. Latest/newest is last
-  orderedActivities = orderBy(cloneDeep(activities), 'date', 'asc');
+  orderedActivities = orderBy(cloneDeep(activities), (a) => new Date(a), 'asc');
 
   const sales = orderedActivities.filter((a) => ['Sell', 'TransferOut'].includes(a.type));
   const purchases = orderedActivities.filter((a) => ['Buy', 'TransferIn'].includes(a.type));

--- a/src/calcInventoryPurchasesFIFO.js
+++ b/src/calcInventoryPurchasesFIFO.js
@@ -70,7 +70,7 @@ module.exports = function calcInventoryPurchasesFIFO(activities, startDate) {
   return {
     realizedGains: realized,
     purchases,
-    capitalWithdrawn: capitalWithdrawn,
+    capitalWithdrawn,
     transferOutAmount: capitalWithdrawnViaTransferOut, // deprecated
     capitalWithdrawnViaTransferOut,
     sellAmount: capitalWidthdrawnViaSales, // deprecated

--- a/utils.js
+++ b/utils.js
@@ -97,7 +97,7 @@ function getPreviousValue(arr, i) {
 
 function calcSalesDataFIFO(activities) {
   // order asc - it's necessary for a FIFO loop. earliest/oldest activity is first in the array. Latest/newest is last
-  orderedActivities = orderBy(cloneDeep(activities), 'date', 'asc');
+  orderedActivities = orderBy(cloneDeep(activities), (a) => new Date(a), 'asc');
 
   // we will make changes to sales that should be reflected in the activities collection
   const sales = orderedActivities.filter((a) => ['Sell', 'TransferOut'].includes(a.type));


### PR DESCRIPTION
Order the activities array as it's needed for FIFO inside the function and don't rely on the incoming order.
Fixes a bug in the API - PR with test will come in the API repo